### PR TITLE
add env var support for deployment creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The environment "test" will be updated to accept traffic from the following host
 ```sh
 > export PUBLIC_HOST "$APIGEE_ORG-$APIGEE_ENVIRONMENT_NAME.apigee.net"
 > export PRIVATE_HOST "$APIGEE_ORG-$APIGEE_ENVIRONMENT_NAME.apigee.net"
-> shipyardctl create deployment "test" "example" $PUBLIC_HOST $PRIVATE_HOST 1 $PTS_URL
+> shipyardctl create deployment "test" "example" $PUBLIC_HOST $PRIVATE_HOST 1 $PTS_URL -e "NAME1=VALUE1" -e "NAME2=VALUE2"
 ```
 This creates a new deployment within the "test" environment with the previously generated PTS URL. The number 1 represents the number
 of replicas to be made and "example" is the name of the deployment.


### PR DESCRIPTION
Fixes #10 

Add support for deploy-time environment variable configuration via a command line flag

Usage:

``` sh
> shipyardctl create deployment test exampleApp $PUBLIC_HOST $PRIVATE_HOST 1 $PTS_URL \
--env "NAME=VALUE" --env "NAME=VALUE"
```
