### PR TITLE
use config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #Format is MAJOR . MINOR . PATCH
 
-VERSION=1.2.1
+VERSION=1.3.0
 GO_VERSION=1.6
 
 release: package-linux package-windows package-darwin

--- a/README.md
+++ b/README.md
@@ -1,19 +1,49 @@
-#shipyardctl
+# shipyardctl
 
 This project is a command line interface that wraps the Shipyard build and deploy APIs.
 
 **While the usage is similar to `kubectl`, this is not meant to replace `kubectl`, but merely to wrap the many available API resources of Shipyard**
 
-###Installation
+### Installation
 Download the proper binary from the releases section of the repo, [here](https://github.com/30x/shipyardctl/releases).
 
 ```sh
-> wget https://github.com/30x/shipyardctl/releases/download/v1.2.1/shipyardctl-1.2.1.darwin.amd64.go1.6.tar.gz
+> wget https://github.com/30x/shipyardctl/releases/download/v1.3.0/shipyardctl-1.3.0.darwin.amd64.go1.6.tar.gz
 > tar -xvf shipyardctl-1.3.0.darwin.amd64.go1.6.tar.gz
 > mv shipyardctl /usr/local/bin # might need sudo access
 ```
 
-###Configuration and Environment
+### Configuration and Environment
+
+**Configurable values**
+
+Here are some of the values that `shipyardctl` uses. A few of them have meaningful defaults that will not need to be changed for regular use. If there is no default, it is a user supplied value.
+Each value has a few ways to be configured. Take notice of the different options you have (CLI Flag, environment variable and config file).
+
+| Env Var | CLI Flag | In config file? | Default | Description |
+| ------- |:--------:| ---------------:| -------:| -----------:|
+|`APIGEE_ORG`|`--org -o`| no | n/a | Your Apigee org name|
+|`APIGEE_ENVIRONMENT_NAME`|`--envName -e`| no | n/a | Your Apigee env name|
+|`APIGEE_TOKEN` |`--token -t`| yes | n/a | Your JWT access token generated from Apigee credentials|
+|`CLUSTER_TARGET`| n/a | yes | "https://shipyard.apigee.com" | The _protocol_ and _hostname_ of the k8s cluster |
+|`SSO_LOGIN_URL`| n/a | yes | "https://login.apigee.com" | The _protocol_ and _hostname_ of the SSO target |
+
+**Configuration resolution hierarchy**
+
+The above variables will resolve in the following order where supported:
+* CLI Flag
+* Enviroment variable
+* Config file
+
+**When to use what**
+
+Often times the values that are available to the configuration file should be managed in the config file. Using environment variables can be cumbersome and tricky to debug if you forget there is one set.
+However, if you want to briefly change a value, take the token used to authenticate your `shipyardctl` calls for example, using the environment variable or CLI flag is useful and easy to undo.
+
+The values that are not currently available to the configuration file (i.e. `org` and `envName`) should be configured with CLI flags when switching between combinations often and in envrionment variables when working in one combo for a while, to reduce command verbosity.
+
+**Example config file**
+
 Upon first use of `shipyarctl` it will write a configuration file to `$HOME/.shipyardctl/config`. The config file looks something like this on creation:
 ```yaml
 currentcontext: default
@@ -21,33 +51,22 @@ contexts:
 - name: default
   clusterinfo:
     name: default
-    clustertarget: https://shipyard.apigee.com
-    ssotarget: https://login.apigee.com
+    cluster: https://shipyard.apigee.com # CLUSTER_TARGET
+    sso: https://login.apigee.com # SSO_LOGIN_URL
   userinfo:
     username: ""
-    token: ""
+    token: "" # APIGEE_TOKEN
 ```
 `currentcontext`: name of the context to be referencing in `shipyardctl` use
 `contexts`: set of named contexts containing cluster information and user credentials
-_Note: The `userinfo` property of a new context will be blank until you login._
+> _Note: The `userinfo` property of a new context will be blank until you login._
 
-**Environment**
+**What is a context?**
 
-| Env Var | CLI Flag | Description |
-| ------- |:--------:| -----------:|
-|`APIGEE_ORG`|`--org -o`| Your Apigee org name|
-|`APIGEE_ENVIRONMENT_NAME`|`--envName -e`| Your Apigee env name|
-|`APIGEE_TOKEN` |`--token -t`|Your JWT access token generated from Apigee credentials|
-|`CLUSTER_TARGET`| n/a |The _protocol_ and _hostname_ of the k8s cluster (**default:** "https://shipyard.apigee.com")|
-|`SSO_LOGIN_URL`| n/a |The _protocol_ and _hostname_ of the SSO target (**default:** "https://login.apigee.com")|
+A context contains the information about the cluster you are targetting with `shipyardctl` and user info that you are currently logged in as. When consume Shipyard regularly, the `default` context is all you will need.
+If you are, however, running your own instance(s) of Shipyard, then having multiple contexts to easily switch your target is necessary.
 
-**Configuration hierarchy**
-The above variables will resolve in the following order:
-* CLI Flag (when supported)
-* Enviroment variable
-* Config file
-
-###Usage
+### Usage
 
 The list of available commands is as follows:
 ```
@@ -81,17 +100,17 @@ All commands support verbose output with the `-v` or `--verbose` flag.
 
 Please also see `shipyardctl --help` for more information on the available commands and their arguments.
 
-###Managing your config file
+### Managing your config file
 
 The config file shouldn't need to be changed much, unless you are developing on Shipyard or running your own cluster. Regardless, here are the available config management commands:
 
-**View**
+**Viewing your config file**
 ```sh
 > shipyarctl config view
 ```
 Prints the config file to stdout.
 
-**New Context**
+**Creating a new context**
 ```sh
 > shipyarctl config new-context "e2e" --cluster-target=https://my.e2e.shipyard.com --sso-target=https://my.apigee.sso.com
 New context e2e added!
@@ -101,15 +120,17 @@ This creates a new cluster context. As mentioned before, this is helpful when yo
 separate instance of Shipyard on a different cluster.
 _Note: should any of the flags shown above be excluded, the default value will be used._
 
-**Switch Context**
+**Switching contexts**
 ```sh
 > shipyardctl config use-context "e2e"
 ```
 This switches the `currentcontext` property so that all following `shipyardctl` commands reference it.
 
-####Walk through
+## Walk through
 
-**Login**
+During this walk through, we will go through the steps of building, deploying and managing a Node.js applicaion on Shipyard.
+
+**1. Login**
 ```sh
 > shipyardctl login --username orgAdmin@gmail.com
 No config file present. Creating one now.
@@ -128,9 +149,12 @@ Successfully wrote credentials to /my/home/directory/.shipyardctl/config
 This logs you in to a `shipyardctl` session by retrieving an auth token with your Apigee credentials and saving it to a
 configuration file placed in your home directory.
 
-_Note: this token expires quickly, so make sure to refresh it about every 30 minutes._
+> _Note: this token expires quickly, so make sure to refresh it about every 30 minutes._
 
-**Build an image of a Node.js app**
+**2. Build an image of a Node.js app**
+
+This command consumes the Node.js application zip, builds it into an image, stores the image and provides the URL to retrieve its spec.
+
 ```sh
 > shipyardctl create image "example" 1 "9000:/example" "./example-app.zip"
 > export PTS_URL="<copy the Pod Template Spec URL generated and output by the build image command>"
@@ -138,15 +162,18 @@ _Note: this token expires quickly, so make sure to refresh it about every 30 min
 The build command takes the name of your application, the revision number, the public port/path to reach your application
 and the path to your zipped Node app.
 
-_Note: there must be a valid package.json in the root of zipped application_
+> _Note: there must be a valid package.json in the root of zipped application_
 
-**Verify image creation**
+**3. Verify image creation**
 ```sh
 > shipyardctl get image example 1
 ```
 This retrieves the available information for the image specified by the application name and revision number
 
-**Create a new environment**
+**4. Create a new environment**
+
+This command will create the environment that will host your deployed Node.js applications.
+
 ```sh
 > shipyardctl create environment "org1:env1" "<org name>-test.apigee.net" "<org name>-prod.apigee.net"
 > export PUBLIC_KEY="<copy public key in creation response here>"
@@ -154,21 +181,24 @@ This retrieves the available information for the image specified by the applicat
 Here we create a new environment with the name "org1:env1" and the accepted hostnames of "orgName-test.apigee.net"
 and "orgName-prod.apigee.net", a space delimited list.
 
-_Note: the naming convention used for hostnames is not strictly enforced, but will make Apigee Edge integration easier_
+> _Note: the naming convention used for hostnames is not strictly enforced, but will make Apigee Edge integration easier_
 
-**Retrieve the newly created environment by name**
+**5. Retrieve the newly created environment by name**
 ```sh
 > shipyardctl get environment "org1:env1"
 ```
 Here we have retrieved the newly created environment, by name.
 
-**Update the environment's set of accepted hostnames**
+**6. Update the environment's set of accepted hostnames**
 ```sh
 > shipyardctl patch environment "org1:env1" "test.host.name3" "test.host.name4"
 ```
 The environment "org1:env1" will be updated to accept traffic from the following hostnames, explicitly.
 
-**Create a new deployment**
+**7. Create a new deployment**
+
+This command will create the deployment artifact that is used to manage your deployed Node.js application.
+
 ```sh
 > export PUBLIC_HOST "$APIGEE_ORG-$APIGEE_ENVIRONMENT_NAME.apigee.net"
 > export PRIVATE_HOST "$APIGEE_ORG-$APIGEE_ENVIRONMENT_NAME.apigee.net"
@@ -177,13 +207,13 @@ The environment "org1:env1" will be updated to accept traffic from the following
 This creates a new deployment within the "org1:env1" environment with the previously generated PTS URL. The number 1 represents the number
 of replicas to be made and "example" is the name of the deployment.
 
-**Retrieve newly created deployment by name**
+**8. Retrieve newly created deployment by name**
 ```sh
 > shipyardctl get deployment "org1:env1" "example"
 ```
 The response will include all available information on the active deployment in the given environment.
 
-**Update the deployment**
+**9. Update the deployment**
 ```sh
 > shipyardctl patch deployment "org1:env1" "example" '{"replicas": 3, "publicHosts": "replacement.host.name"}'
 ```
@@ -195,7 +225,7 @@ This includes:
 - pod template spec URL
 - pod template spec
 
-**Create Apigee Edge Proxy bundle**
+**10. Create Apigee Edge Proxy bundle**
 ```sh
 > shipyardctl create bundle "myEnvironment" --save ~/Desktop
 ```
@@ -204,25 +234,25 @@ all applications deployed to the Shipyard enviroment associated with the working
 Zip this folder (named "apiproxy"), name it with your proxy name, and upload this to Apigee Edge.
 Make sure to deploy the proxy after uploading it.
 
-_Note: you can customize the proxy base path with the `--basePath` flag. We recommend that you first create a proxy with the default base path of `/` for the_
-_entire environemnt, then make individual proxies with specific base paths **when necessary**._
+> _Note: you can customize the proxy base path with the `--basePath` flag. We recommend that you first create a proxy with the default base path of `/` for the_
+> _entire environemnt, then make individual proxies with specific base paths **when necessary**._
 
 > We are unable to zip the bundle for you as the zip generated by the native Go lang `archive/zip` package is not compatible
 > with native Java zip packages. See [this forum](http://webmail.dev411.com/p/gg/golang-nuts/155g3s6g53/go-nuts-re-zip-files-created-with-archive-zip-arent-recognised-as-zip-files-by-java-util-zip) for an explanation.
 
-**Delete the deployment**
+**11. Delete the deployment**
 ```sh
 > shipyardctl delete deployment "org1:env1" "example"
 ```
 This deletes the named deployment.
 
-**Delete the environment**
+**12. Delete the environment**
 ```sh
 > shipyardctl delete environment "org1:env1"
 ```
 This deletes the named environment.
 
-**Delete the image**
+**13. Delete the image**
 ```sh
 > shipyardctl delete image "example" 1
 ```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,49 @@
-#shipyardctl
+# shipyardctl
 
 This project is a command line interface that wraps the Shipyard build and deploy APIs.
 
 **While the usage is similar to `kubectl`, this is not meant to replace `kubectl`, but merely to wrap the many available API resources of Shipyard**
 
-###Installation
+### Installation
 Download the proper binary from the releases section of the repo, [here](https://github.com/30x/shipyardctl/releases).
 
 ```sh
-> wget https://github.com/30x/shipyardctl/releases/download/v1.2.1/shipyardctl-1.2.1.darwin.amd64.go1.6.tar.gz
+> wget https://github.com/30x/shipyardctl/releases/download/v1.3.0/shipyardctl-1.3.0.darwin.amd64.go1.6.tar.gz
 > tar -xvf shipyardctl-1.3.0.darwin.amd64.go1.6.tar.gz
 > mv shipyardctl /usr/local/bin # might need sudo access
 ```
 
-###Configuration and Environment
+### Configuration and Environment
+
+**Configurable values**
+
+Here are some of the values that `shipyardctl` uses. A few of them have meaningful defaults that will not need to be changed for regular use. If there is no default, it is a user supplied value.
+Each value has a few ways to be configured. Take notice of the different options you have (CLI Flag, environment variable and config file).
+
+| Env Var | CLI Flag | In config file? | Default | Description |
+| ------- |:--------:| ---------------:| -------:| -----------:|
+|`APIGEE_ORG`|`--org -o`| no | n/a | Your Apigee org name|
+|`APIGEE_ENVIRONMENT_NAME`|`--envName -e`| no | n/a | Your Apigee env name|
+|`APIGEE_TOKEN` |`--token -t`| yes | n/a | Your JWT access token generated from Apigee credentials|
+|`CLUSTER_TARGET`| n/a | yes | "https://shipyard.apigee.com" | The _protocol_ and _hostname_ of the k8s cluster |
+|`SSO_LOGIN_URL`| n/a | yes | "https://login.apigee.com" | The _protocol_ and _hostname_ of the SSO target |
+
+**Configuration resolution hierarchy**
+
+The above variables will resolve in the following order where supported:
+* CLI Flag
+* Enviroment variable
+* Config file
+
+**When to use what**
+
+Often times the values that are available to the configuration file should be managed in the config file. Using environment variables can be cumbersome and tricky to debug if you forget there is one set.
+However, if you want to briefly change a value, take the token used to authenticate your `shipyardctl` calls for example, using the environment variable or CLI flag is useful and easy to undo.
+
+The values that are not currently available to the configuration file (i.e. `org` and `envName`) should be configured with CLI flags when switching between combinations often and in envrionment variables when working in one combo for a while, to reduce command verbosity.
+
+**Example config file**
+
 Upon first use of `shipyarctl` it will write a configuration file to `$HOME/.shipyardctl/config`. The config file looks something like this on creation:
 ```yaml
 currentcontext: default
@@ -21,33 +51,22 @@ contexts:
 - name: default
   clusterinfo:
     name: default
-    clustertarget: https://shipyard.apigee.com
-    ssotarget: https://login.apigee.com
+    cluster: https://shipyard.apigee.com # CLUSTER_TARGET
+    sso: https://login.apigee.com # SSO_LOGIN_URL
   userinfo:
     username: ""
-    token: ""
+    token: "" # APIGEE_TOKEN
 ```
 `currentcontext`: name of the context to be referencing in `shipyardctl` use
 `contexts`: set of named contexts containing cluster information and user credentials
-_Note: The `userinfo` property of a new context will be blank until you login._
+> _Note: The `userinfo` property of a new context will be blank until you login._
 
-**Environment**
+**What is a context?**
 
-| Env Var | CLI Flag | Description |
-| ------- |:--------:| -----------:|
-|`APIGEE_ORG`|`--org -o`| Your Apigee org name|
-|`APIGEE_ENVIRONMENT_NAME`|`--envName -e`| Your Apigee env name|
-|`APIGEE_TOKEN` |`--token -t`|Your JWT access token generated from Apigee credentials|
-|`CLUSTER_TARGET`| n/a |The _protocol_ and _hostname_ of the k8s cluster (**default:** "https://shipyard.apigee.com")|
-|`SSO_LOGIN_URL`| n/a |The _protocol_ and _hostname_ of the SSO target (**default:** "https://login.apigee.com")|
+A context contains the information about the cluster you are targetting with `shipyardctl` and user info that you are currently logged in as. When consume Shipyard regularly, the `default` context is all you will need.
+If you are, however, running your own instance(s) of Shipyard, then having multiple contexts to easily switch your target is necessary.
 
-**Configuration hierarchy**
-The above variables will resolve in the following order:
-* CLI Flag (when supported)
-* Enviroment variable
-* Config file
-
-###Usage
+### Usage
 
 The list of available commands is as follows:
 ```
@@ -81,17 +100,17 @@ All commands support verbose output with the `-v` or `--verbose` flag.
 
 Please also see `shipyardctl --help` for more information on the available commands and their arguments.
 
-###Managing your config file
+### Managing your config file
 
 The config file shouldn't need to be changed much, unless you are developing on Shipyard or running your own cluster. Regardless, here are the available config management commands:
 
-**View**
+**Viewing your config file**
 ```sh
 > shipyarctl config view
 ```
 Prints the config file to stdout.
 
-**New Context**
+**Creating a new context**
 ```sh
 > shipyarctl config new-context "e2e" --cluster-target=https://my.e2e.shipyard.com --sso-target=https://my.apigee.sso.com
 New context e2e added!
@@ -101,15 +120,17 @@ This creates a new cluster context. As mentioned before, this is helpful when yo
 separate instance of Shipyard on a different cluster.
 _Note: should any of the flags shown above be excluded, the default value will be used._
 
-**Switch Context**
+**Switching contexts**
 ```sh
 > shipyardctl config use-context "e2e"
 ```
 This switches the `currentcontext` property so that all following `shipyardctl` commands reference it.
 
-####Walk through
+## Walk through
 
-**Login**
+During this walk through, we will go through the steps of building, deploying and managing a Node.js applicaion on Shipyard.
+
+**1. Login**
 ```sh
 > shipyardctl login --username orgAdmin@gmail.com
 No config file present. Creating one now.
@@ -128,9 +149,12 @@ Successfully wrote credentials to /my/home/directory/.shipyardctl/config
 This logs you in to a `shipyardctl` session by retrieving an auth token with your Apigee credentials and saving it to a
 configuration file placed in your home directory.
 
-_Note: this token expires quickly, so make sure to refresh it about every 30 minutes._
+> _Note: this token expires quickly, so make sure to refresh it about every 30 minutes._
 
-**Build an image of a Node.js app**
+**2. Build an image of a Node.js app**
+
+This command consumes the Node.js application zip, builds it into an image, stores the image and provides the URL to retrieve its spec.
+
 ```sh
 > shipyardctl create image "example" 1 "9000:/example" "./example-app.zip"
 > export PTS_URL="<copy the Pod Template Spec URL generated and output by the build image command>"
@@ -141,15 +165,18 @@ and the path to your zipped Node app.
 **This command defaults to using Node.js LTS (v4) unless otherwise specified with the `--node-version` flag.**
 **A list of available versions can be found [here](https://github.com/mhart/alpine-node#minimal-nodejs-docker-images-18mb-or-67mb-compressed). Provide the desired image tag as the `--node-version`.**
 
-_Note: there must be a valid package.json in the root of zipped application_
+> _Note: there must be a valid package.json in the root of zipped application_
 
-**Verify image creation**
+**3. Verify image creation**
 ```sh
 > shipyardctl get image example 1
 ```
 This retrieves the available information for the image specified by the application name and revision number
 
-**Create a new environment**
+**4. Create a new environment**
+
+This command will create the environment that will host your deployed Node.js applications.
+
 ```sh
 > shipyardctl create environment "org1:env1" "<org name>-test.apigee.net" "<org name>-prod.apigee.net"
 > export PUBLIC_KEY="<copy public key in creation response here>"
@@ -157,21 +184,24 @@ This retrieves the available information for the image specified by the applicat
 Here we create a new environment with the name "org1:env1" and the accepted hostnames of "orgName-test.apigee.net"
 and "orgName-prod.apigee.net", a space delimited list.
 
-_Note: the naming convention used for hostnames is not strictly enforced, but will make Apigee Edge integration easier_
+> _Note: the naming convention used for hostnames is not strictly enforced, but will make Apigee Edge integration easier_
 
-**Retrieve the newly created environment by name**
+**5. Retrieve the newly created environment by name**
 ```sh
 > shipyardctl get environment "org1:env1"
 ```
 Here we have retrieved the newly created environment, by name.
 
-**Update the environment's set of accepted hostnames**
+**6. Update the environment's set of accepted hostnames**
 ```sh
 > shipyardctl patch environment "org1:env1" "test.host.name3" "test.host.name4"
 ```
 The environment "org1:env1" will be updated to accept traffic from the following hostnames, explicitly.
 
-**Create a new deployment**
+**7. Create a new deployment**
+
+This command will create the deployment artifact that is used to manage your deployed Node.js application.
+
 ```sh
 > export PUBLIC_HOST "$APIGEE_ORG-$APIGEE_ENVIRONMENT_NAME.apigee.net"
 > export PRIVATE_HOST "$APIGEE_ORG-$APIGEE_ENVIRONMENT_NAME.apigee.net"
@@ -180,13 +210,13 @@ The environment "org1:env1" will be updated to accept traffic from the following
 This creates a new deployment within the "org1:env1" environment with the previously generated PTS URL. The number 1 represents the number
 of replicas to be made and "example" is the name of the deployment.
 
-**Retrieve newly created deployment by name**
+**8. Retrieve newly created deployment by name**
 ```sh
 > shipyardctl get deployment "org1:env1" "example"
 ```
 The response will include all available information on the active deployment in the given environment.
 
-**Update the deployment**
+**9. Update the deployment**
 ```sh
 > shipyardctl patch deployment "org1:env1" "example" '{"replicas": 3, "publicHosts": "replacement.host.name"}'
 ```
@@ -198,7 +228,7 @@ This includes:
 - pod template spec URL
 - pod template spec
 
-**Create Apigee Edge Proxy bundle**
+**10. Create Apigee Edge Proxy bundle**
 ```sh
 > shipyardctl create bundle "myEnvironment" --save ~/Desktop
 ```
@@ -207,25 +237,25 @@ all applications deployed to the Shipyard enviroment associated with the working
 Zip this folder (named "apiproxy"), name it with your proxy name, and upload this to Apigee Edge.
 Make sure to deploy the proxy after uploading it.
 
-_Note: you can customize the proxy base path with the `--basePath` flag. We recommend that you first create a proxy with the default base path of `/` for the_
-_entire environemnt, then make individual proxies with specific base paths **when necessary**._
+> _Note: you can customize the proxy base path with the `--basePath` flag. We recommend that you first create a proxy with the default base path of `/` for the_
+> _entire environemnt, then make individual proxies with specific base paths **when necessary**._
 
 > We are unable to zip the bundle for you as the zip generated by the native Go lang `archive/zip` package is not compatible
 > with native Java zip packages. See [this forum](http://webmail.dev411.com/p/gg/golang-nuts/155g3s6g53/go-nuts-re-zip-files-created-with-archive-zip-arent-recognised-as-zip-files-by-java-util-zip) for an explanation.
 
-**Delete the deployment**
+**11. Delete the deployment**
 ```sh
 > shipyardctl delete deployment "org1:env1" "example"
 ```
 This deletes the named deployment.
 
-**Delete the environment**
+**12. Delete the environment**
 ```sh
 > shipyardctl delete environment "org1:env1"
 ```
 This deletes the named environment.
 
-**Delete the image**
+**13. Delete the image**
 ```sh
 > shipyardctl delete image "example" 1
 ```

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ _Note: this token expires quickly, so make sure to refresh it about every 30 min
 The build command takes the name of your application, the revision number, the public port/path to reach your application
 and the path to your zipped Node app.
 
+**This command defaults to using Node.js LTS (v4) unless otherwise specified with the `--node-version` flag.**
+**A list of available versions can be found [here](https://github.com/mhart/alpine-node#minimal-nodejs-docker-images-18mb-or-67mb-compressed). Provide the desired image tag as the `--node-version`.**
+
 _Note: there must be a valid package.json in the root of zipped application_
 
 **Verify image creation**

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+  "fmt"
+  "os"
+  "log"
+
+  "github.com/spf13/cobra"
+  "github.com/30x/shipyardctl/utils"
+)
+
+var cluster string
+var sso string
+
+var useContextCmd = &cobra.Command{
+	Use:   "use-context",
+	Short: "switch context",
+	Long: `Switch shipyardctl context to given context name.
+You should login again after using this, to be sure the token is fresh.
+
+Example of use:
+
+$ shipyardctl config use-context e2e`,
+	Run: func(cmd *cobra.Command, args []string) {
+    if len(args) < 1 {
+      fmt.Println("Missing required context name")
+      os.Exit(-1)
+    }
+
+    contextName := args[0]
+
+    if config == nil { // no config file
+      fmt.Println("There is no config file present at:", utils.GetConfigPath())
+    } else { // switch the current context to give name
+      err := config.SetContext(contextName)
+      if err != nil {
+        fmt.Println(err)
+        os.Exit(-1)
+      }
+    }
+
+    return
+	},
+}
+
+var newContextCmd = &cobra.Command{
+	Use:   "new-context <name>",
+	Short: "new-context",
+	Long: `Create a new configuration context with given name.
+Cluster target information will default to cluster-target=https://shipyard.apigee.com
+and sso-target=https://login.apigee.com unless otherwise specified.
+
+Example of use:
+
+$ shipyardctl config new-context e2e`,
+	Run: func(cmd *cobra.Command, args []string) {
+    if len(args) < 1 {
+      fmt.Println("Missing required context name")
+      os.Exit(-1)
+    }
+
+    contextName := args[0]
+
+    if config == nil { // no config file
+      fmt.Println("There is no config file present at:", utils.GetConfigPath())
+    } else { // switch the current context to give name
+      err := config.NewContext(contextName, sso, cluster)
+      if err != nil {
+        fmt.Println(err)
+        os.Exit(-1)
+      }
+    }
+
+    fmt.Printf("New context %s added!\nPlease switch contexts and login.\n", contextName)
+
+    return
+	},
+}
+
+var viewConfigCmd = &cobra.Command{
+	Use:   "view",
+	Short: "view",
+	Long: `Prints out the config file present at $HOME/.shipyardctl/config
+
+Example of use:
+
+$ shipyardctl config view`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+    if config == nil { // no config file
+      fmt.Println("There is no config file present at:", utils.GetConfigPath())
+    } else { // dump config file to stdout
+      err := config.DumpConfig()
+      if err != nil {
+        log.Fatal(err)
+      }
+    }
+
+    return
+	},
+}
+
+var ConfigCmd = &cobra.Command{
+	Use:   "config <sub-command>",
+	Short: "config based commands",
+	Long: `Supports all of the configuration based commands for shipyardctl.
+
+Example of use:
+
+$ shipyardctl config use-context e2e
+
+$ shipyardctl config view
+
+$ shipyardctl config new-context prod --cluster-target=https://my.shipyard.com`,
+}
+
+func init() {
+  ConfigCmd.AddCommand(viewConfigCmd)
+	ConfigCmd.AddCommand(useContextCmd)
+  ConfigCmd.AddCommand(newContextCmd)
+  newContextCmd.Flags().StringVarP(&cluster, "cluster-target", "c", "https://shipyard.apigee.com", "Indicates the URL of the target cluster")
+  newContextCmd.Flags().StringVarP(&sso, "sso-target", "s", "https://login.apigee.com", "Indicates the URL of the SSO target")
+  RootCmd.AddCommand(ConfigCmd)
+}

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -95,6 +95,9 @@ $ shipyardctl get deployment dep1 --token <token>`,
 			}
 
 			defer response.Body.Close()
+
+			CheckIfAuthn(response.StatusCode)
+
 			_, err = io.Copy(os.Stdout, response.Body)
 			if err != nil {
 				log.Fatal(err)
@@ -128,6 +131,9 @@ $ shipyardctl get deployment dep1 --token <token>`,
 
 			// dump response body to stdout
 			defer response.Body.Close()
+
+			CheckIfAuthn(response.StatusCode)
+
 			_, err = io.Copy(os.Stdout, response.Body)
 			if err != nil {
 				log.Fatal(err)
@@ -185,7 +191,10 @@ $ shipyardctl delete deployment org1:env1 dep1 --token <token>`,
 		defer response.Body.Close()
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
 			fmt.Println("\nDeletion of " + depName + " in " + envName + " was sucessful\n")
+		} else {
+			CheckIfAuthn(response.StatusCode)
 		}
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)
@@ -253,7 +262,10 @@ $ shipyardctl create deployment org1:env1 dep1 "test.host.name" "test.host.name"
 		defer response.Body.Close()
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
 			fmt.Println("\nCreation of " + depName + " in " + envName + " was sucessful\n")
+		} else {
+			CheckIfAuthn(response.StatusCode)
 		}
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)
@@ -308,7 +320,10 @@ $ shipyardctl patch deployment org1:env1 dep1 '{"replicas": 3, "publicHosts": "t
 		defer response.Body.Close()
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
 			fmt.Println("\nPatch of " + depName + " in " + envName + " was sucessful\n")
+		} else {
+			CheckIfAuthn(response.StatusCode)
 		}
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)
@@ -369,6 +384,9 @@ $ shipyardctl get logs org1:env1 dep1 --token <token>`,
 
 		// dump response body to stdout
 		defer response.Body.Close()
+
+		CheckIfAuthn(response.StatusCode)
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -75,6 +75,9 @@ $ shipyardctl get environment org1:env1 --token <token>`,
 		}
 
 		defer response.Body.Close()
+
+		CheckIfAuthn(response.StatusCode)
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)
@@ -118,7 +121,10 @@ $ shipyardctl delete environment org1:env1 --token <token>`,
 		defer response.Body.Close()
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
 			fmt.Println("\nDeletion of " + envName + " was sucessful\n")
+		} else {
+			CheckIfAuthn(response.StatusCode)
 		}
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)
@@ -175,7 +181,10 @@ $ shipyardctl create environment org1:env1 "test.host.name1" "test.host.name2" -
 		defer response.Body.Close()
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
 			fmt.Println("\nCreation of " + envName + " was sucessful\n")
+		} else {
+			CheckIfAuthn(response.StatusCode)
 		}
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)
@@ -232,6 +241,8 @@ $ shipyardctl patch org1:env1 "test.host.name3" "test.host.name4" --token <token
 		defer response.Body.Close()
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
 			fmt.Println("\nPatch of " + envName + " was sucessful\n")
+		} else {
+			CheckIfAuthn(response.StatusCode)
 		}
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -109,6 +109,8 @@ $ shipyardctl create image example 1 "9000:/example" "./path/to/zipped/app --org
 		defer response.Body.Close()
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
 			fmt.Println("\nImage build successful\n")
+		} else {
+			CheckIfAuthn(response.StatusCode)
 		}
 
 		_, err = io.Copy(os.Stdout, response.Body)
@@ -162,6 +164,9 @@ $ shipyardctl get image example --all --org org1 --token <token>`,
 			}
 
 			defer response.Body.Close()
+
+			CheckIfAuthn(response.StatusCode)
+
 			_, err = io.Copy(os.Stdout, response.Body)
 			if err != nil {
 				log.Fatal(err)
@@ -193,6 +198,9 @@ $ shipyardctl get image example --all --org org1 --token <token>`,
 			}
 
 			defer response.Body.Close()
+
+			CheckIfAuthn(response.StatusCode)
+
 			_, err = io.Copy(os.Stdout, response.Body)
 			if err != nil {
 				log.Fatal(err)
@@ -242,6 +250,9 @@ $ shipyardctl delete image example 1 --org org1 --token <token>`,
 		}
 
 		defer response.Body.Close()
+
+		CheckIfAuthn(response.StatusCode)
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -112,6 +112,8 @@ $ shipyardctl create image example 1 "9000:/example" "./path/to/zipped/app --org
 		defer response.Body.Close()
 		if response.StatusCode >= 200 && response.StatusCode < 300 {
 			fmt.Println("\nImage build successful\n")
+		} else {
+			CheckIfAuthn(response.StatusCode)
 		}
 
 		_, err = io.Copy(os.Stdout, response.Body)
@@ -165,6 +167,9 @@ $ shipyardctl get image example --all --org org1 --token <token>`,
 			}
 
 			defer response.Body.Close()
+
+			CheckIfAuthn(response.StatusCode)
+
 			_, err = io.Copy(os.Stdout, response.Body)
 			if err != nil {
 				log.Fatal(err)
@@ -196,6 +201,9 @@ $ shipyardctl get image example --all --org org1 --token <token>`,
 			}
 
 			defer response.Body.Close()
+
+			CheckIfAuthn(response.StatusCode)
+
 			_, err = io.Copy(os.Stdout, response.Body)
 			if err != nil {
 				log.Fatal(err)
@@ -245,6 +253,9 @@ $ shipyardctl delete image example 1 --org org1 --token <token>`,
 		}
 
 		defer response.Body.Close()
+
+		CheckIfAuthn(response.StatusCode)
+
 		_, err = io.Copy(os.Stdout, response.Body)
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var nodeVersion string
+
 // imageCmd represents the image command
 var imageCmd = &cobra.Command{
 	Use:   "image <appName> <revision> <publicPath> <zipPath>",
@@ -78,6 +80,7 @@ $ shipyardctl create image example 1 "9000:/example" "./path/to/zipped/app --org
 		writer.WriteField("revision", revision)
 		writer.WriteField("name", appName)
 		writer.WriteField("publicPath", publicPath)
+		writer.WriteField("nodeVersion", nodeVersion)
 
 		err = writer.Close()
 		if err != nil {
@@ -253,6 +256,7 @@ func init() {
 	createCmd.AddCommand(imageCmd)
 	imageCmd.Flags().StringSliceVarP(&envVars, "env", "e", []string{}, "Environment variable to set in the built image \"KEY=VAL\" ")
 	imageCmd.Flags().StringVarP(&orgName, "org", "o", "", "Apigee org name")
+	imageCmd.Flags().StringVarP(&nodeVersion, "node-version", "n", "4", "Node version to use in base image.")
 
 	getCmd.AddCommand(getImageCmd)
 	getImageCmd.Flags().StringVarP(&orgName, "org", "o", "", "Apigee org name")

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -28,88 +28,99 @@ import (
 
 	"github.com/spf13/cobra"
   "github.com/howeyc/gopass"
+  "github.com/30x/shipyardctl/utils"
 )
 
 var username string
 var password string
-var sso_target string
 var mfa string
 
 type AuthResponse struct {
   Access_token string `json:"access_token"`
 }
 
-var tokenCmd = &cobra.Command{
-	Use:   "token",
+var loginCmd = &cobra.Command{
+	Use:   "login",
 	Short: "get new auth token",
 	Long: `This retrieves a new JWT token based on Apigee credentials.
 
 Example of use:
 
-$ shipyardctl get token -u orgAdmin@apigee.com`,
+$ shipyardctl login -u orgAdmin@apigee.com`,
 	Run: func(cmd *cobra.Command, args []string) {
-    configureSSOTarget()
-    requireUsername()
-    requirePassword()
-    askForMFA()
+    Login()
 
-    data := url.Values{}
-    data.Add("username", username)
-    data.Add("password", password)
-    data.Add("grant_type", "password")
-    payload := bytes.NewBufferString(data.Encode())
-    clientAuth := "ZWRnZWNsaTplZGdlY2xpc2VjcmV0"
-
-    var req *http.Request
-    var err error
-    if mfa == "" {
-		  req, err = http.NewRequest("POST", sso_target + "/oauth/token", payload)
-    } else {
-      req, err = http.NewRequest("POST", sso_target + "/oauth/token?mfa_token="+mfa, payload)
-    }
-
-    req.Header.Set("Authorization", "Basic " + clientAuth)
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
-    req.Header.Add("Accept", "application/json;charset=utf-8")
-
-		response, err := http.DefaultClient.Do(req)
-
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		defer response.Body.Close()
-    body, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-    auth := AuthResponse{}
-    err = json.Unmarshal(body, &auth)
-    if err != nil {
-      log.Fatal(err)
-    }
-
-    fmt.Println("Copy this to your environment:")
-    fmt.Println(auth.Access_token)
     return
 	},
 }
 
-func init() {
-	getCmd.AddCommand(tokenCmd)
-	tokenCmd.Flags().StringVarP(&username, "username", "u", "", "Apigee org admin username")
-  tokenCmd.Flags().StringVarP(&password, "password", "p", "", "Apigee org admin password")
-  tokenCmd.Flags().StringVarP(&sso_target, "sso-login-url", "s", "", "Apigee SSO login url (default https://login.apigee.com)")
+func Login() {
+  requireUsername()
+  requirePassword()
+  askForMFA()
+
+  data := url.Values{}
+  data.Add("username", username)
+  data.Add("password", password)
+  data.Add("grant_type", "password")
+  payload := bytes.NewBufferString(data.Encode())
+  clientAuth := "ZWRnZWNsaTplZGdlY2xpc2VjcmV0"
+
+  var req *http.Request
+  var err error
+  if mfa == "" {
+    req, err = http.NewRequest("POST", sso_target + "/oauth/token", payload)
+  } else {
+    req, err = http.NewRequest("POST", sso_target + "/oauth/token?mfa_token="+mfa, payload)
+  }
+
+  req.Header.Set("Authorization", "Basic " + clientAuth)
+  req.Header.Add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+  req.Header.Add("Accept", "application/json;charset=utf-8")
+
+  response, err := http.DefaultClient.Do(req)
+
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  if response.StatusCode != 200 {
+    fmt.Println("Invalid credentials. Failed to login.")
+    os.Exit(-1)
+  }
+
+  defer response.Body.Close()
+  body, err := ioutil.ReadAll(response.Body)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  auth := AuthResponse{}
+  err = json.Unmarshal(body, &auth)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  if verbose {
+    fmt.Println("Authorization token:")
+    fmt.Println(auth.Access_token)
+  }
+
+  fmt.Println("Writing credentials to current context")
+
+  err = config.SaveToken(username, auth.Access_token)
+  if err != nil {
+    fmt.Print("Failed to write credentials to file.")
+    log.Fatal(err)
+  }
+
+  fmt.Println("Successfully wrote credentials to", utils.GetConfigPath())
 }
 
-
-func configureSSOTarget() {
-  if sso_target == "" {
-    if sso_target = os.Getenv("SSO_LOGIN_URL"); sso_target == "" {
-      sso_target = "https://login.apigee.com"
-    }
-  }
+func init() {
+	RootCmd.AddCommand(loginCmd)
+	loginCmd.Flags().StringVarP(&username, "username", "u", "", "Apigee org admin username")
+  loginCmd.Flags().StringVarP(&password, "password", "p", "", "Apigee org admin password")
 }
 
 func requireUsername() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,11 +103,31 @@ func init() {
 
 // PrintVerboseRequest used to print the request when using verbose
 func PrintVerboseRequest(req *http.Request) {
-	fmt.Println("Current environment:")
-	fmt.Println("CLUSTER_TARGET="+clusterTarget)
-	fmt.Println("APIGEE_ORG="+orgName)
+	context := config.GetCurrentContext()
+	fmt.Println("Current context:")
+	if ct := os.Getenv("CLUSTER_TARGET"); ct != "" {
+		fmt.Printf("Cluster: %s (from environment variable)\n", ct)
+	} else {
+		fmt.Printf("Cluster: %s (from config file)\n", context.ClusterInfo.Cluster)
+	}
 
-	dump, err := httputil.DumpRequestOut(req, true)
+	if st := os.Getenv("SSO_LOGIN_URL"); st != "" {
+		fmt.Printf("SSO login: %s (from environment variable)\n", st)
+	} else {
+		fmt.Printf("SSO login: %s (from config file)\n", context.ClusterInfo.SSO)
+	}
+
+	if org := os.Getenv("APIGEE_ORG"); org != "" {
+		fmt.Printf("Apigee org: %s (from environment variable)\n", org)
+	} else if orgName != "" {
+		fmt.Printf("Apigee org: %s (from CLI flag)\n", orgName)
+	}
+
+	if envName != "" {
+		fmt.Printf("Environment name: %s\n", envName)
+	}
+
+	dump, err := httputil.DumpRequestOut(req, false) // not dump req body
 	if err != nil {
 		fmt.Println("Request dump failed. Request state is unknown. Aborting.")
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -179,6 +179,15 @@ func RequireAuthToken() {
 	return
 }
 
+// CheckIfAuthn checks if the API call was authenticated or not
+func CheckIfAuthn(status int) {
+	if status == 401 {
+		fmt.Println("Your token has expired. Please login again.")
+		fmt.Println("shipyardctl login -u", config.GetCurrentUsername())
+		os.Exit(-1)
+	}
+}
+
 // RequireOrgName used to short circuit commands
 // requiring the Apigee org name if it is not present
 func RequireOrgName() {

--- a/utils/config.go
+++ b/utils/config.go
@@ -1,0 +1,163 @@
+// Copyright © 2016 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+  "fmt"
+  "os"
+  "path/filepath"
+  "io/ioutil"
+
+  yaml "gopkg.in/yaml.v2"
+)
+
+const (
+  // ShipyardctlConfigDir name of the config file directory for shipyardctl
+  ShipyardctlConfigDir = ".shipyardctl"
+  // ShipyardctlConfigFileName name of the config file for shipyardctl
+  ShipyardctlConfigFileName = "config"
+)
+
+// InitNewConfigFile creates a new config file
+func InitNewConfigFile(name string, sso string, clusterTarget string) error {
+
+  home, err := homedir()
+  if err != nil {
+    return err
+  }
+
+  configDirPath := filepath.Join(home, ShipyardctlConfigDir)
+  configFilePath := filepath.Join(configDirPath, ShipyardctlConfigFileName)
+
+  // make sure the directory is there
+  fmt.Println("Creating configuration directory at:", configDirPath)
+  err = os.MkdirAll(configDirPath, 0755)
+  if err != nil {
+    return err
+  }
+
+  fmt.Println("Creating configuration file at:", configFilePath)
+
+  // default config
+  defaultConfig := MakeConfig(name, sso, clusterTarget)
+  data, err := yaml.Marshal(defaultConfig)
+  if err != nil {
+    return err
+  }
+
+  return ioutil.WriteFile(configFilePath, data, 0755)
+}
+
+// MakeConfig creates a context named default based on the given environment
+func MakeConfig(name string, sso string, clusterTarget string) *Config {
+  cluster := Cluster{name, clusterTarget, sso}
+  context := Context{name, cluster, User{}}
+
+  return &Config{name, []Context{context}}
+}
+
+// GetCurrentToken retrieves the user token from the current active context
+func (c *Config) GetCurrentToken() string {
+  for _, con := range c.Contexts {
+    if con.Name == c.CurrentContext {
+      return con.UserInfo.Token
+    }
+  }
+
+  return "" // couldn't find the current Context
+}
+
+// GetCurrentContext retrieves the current context
+func (c *Config) GetCurrentContext() *Context {
+  for _, con := range c.Contexts {
+    if con.Name == c.CurrentContext {
+      return &con
+    }
+  }
+
+  return nil // couldn't find current Context
+}
+
+// SetContext switch current context to given context name
+func (c *Config) SetContext(name string) error {
+  for _, con := range c.Contexts {
+    if con.Name == name { // valid context name
+      c.CurrentContext = name // set current context
+      return c.Save() // save change
+    }
+  }
+
+  return fmt.Errorf("Invalid context name: %s", name)
+}
+
+// Save writes the config out to file
+func (c *Config) Save() error {
+  data, err := yaml.Marshal(c)
+  if err != nil {
+    return err
+  }
+
+  path, err := getConfigPath()
+  if err != nil {
+    return err
+  }
+
+  return ioutil.WriteFile(path, data, 0755)
+}
+
+// GetCurrentClusterTarget retrieves current context cluster target
+func (c *Config) GetCurrentClusterTarget() string {
+  context := c.GetCurrentContext()
+  return context.ClusterInfo.Cluster
+}
+
+// GetCurrentSSOTarget retrieves current context sso target
+func (c *Config) GetCurrentSSOTarget() string {
+  context := c.GetCurrentContext()
+  return context.ClusterInfo.SSO
+}
+
+// NewContext used to create a new context
+func (c *Config) NewContext(name string, sso string, clusterTarget string) error {
+  c.Contexts = append(c.Contexts, Context{name, Cluster{name, clusterTarget, sso}, User{}})
+  c.Save()
+
+  return nil
+}
+
+// DumpConfig dumps the config to stdout
+func (c *Config) DumpConfig() error {
+  data, err := yaml.Marshal(c)
+  if err != nil {
+    return err
+  }
+
+  fmt.Println(string(data))
+
+  return nil
+}
+
+// SaveToken writes the given username and token to the current context
+func (c *Config) SaveToken(username string, token string) error {
+  user := User{username, token}
+  for ndx, con := range c.Contexts {
+    if con.Name == c.CurrentContext {
+      c.Contexts[ndx].UserInfo = user
+      return c.Save()
+    }
+  }
+
+  return fmt.Errorf("Could not find current context: %s", c.CurrentContext)
+}

--- a/utils/config.go
+++ b/utils/config.go
@@ -129,6 +129,12 @@ func (c *Config) GetCurrentSSOTarget() string {
   return context.ClusterInfo.SSO
 }
 
+// GetCurrentUsername retrieves the username of the current context
+func (c *Config) GetCurrentUsername() string {
+  context := c.GetCurrentContext()
+  return context.UserInfo.Username
+}
+
 // NewContext used to create a new context
 func (c *Config) NewContext(name string, sso string, clusterTarget string) error {
   c.Contexts = append(c.Contexts, Context{name, Cluster{name, clusterTarget, sso}, User{}})

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+  "os"
+  "os/user"
+  "io/ioutil"
+  "path/filepath"
+  "fmt"
+
+  yaml "gopkg.in/yaml.v2"
+)
+
+// ConfigExists checks if the config file exists
+func ConfigExists() (bool, error) {
+  path, err := getConfigPath()
+  if err != nil {
+    return false, err
+  }
+  return exists(path)
+}
+
+// GetConfigPath exported version of getConfigPath
+func GetConfigPath() string {
+  path, err := getConfigPath()
+  if err != nil {
+    fmt.Println(err)
+    os.Exit(-1)
+  }
+
+  return path
+}
+
+// LoadConfig reads the config file into memory
+func LoadConfig() (*Config, error) {
+  path, err := getConfigPath()
+  if err != nil {
+    return nil, err
+  }
+
+  config := Config{}
+  data, err := ioutil.ReadFile(path)
+  if err != nil {
+    return nil, err
+  }
+
+  err = yaml.Unmarshal(data, &config)
+  if err != nil {
+    return nil, err
+  }
+
+  return &config, nil
+}
+
+func exists(path string) (bool, error) {
+  _, err := os.Stat(path)
+  if err == nil { return true, nil }
+  if os.IsNotExist(err) { return false, nil }
+  return true, err
+}
+
+func homedir() (string, error) {
+  usr, err := user.Current()
+  if err != nil {
+    return "", err
+  }
+
+  return usr.HomeDir, nil
+}
+
+func getConfigPath() (string, error) {
+  home, err := homedir()
+  if err != nil {
+    return "", err
+  }
+
+  return filepath.Join(home, ShipyardctlConfigDir, ShipyardctlConfigFileName), err
+}

--- a/utils/types.go
+++ b/utils/types.go
@@ -1,0 +1,27 @@
+package utils
+
+// Cluster representation of a target cluster
+type Cluster struct {
+  Name string
+  Cluster string
+  SSO string
+}
+
+// User representation of a user's credentials
+type User struct {
+  Username string
+  Token string
+}
+
+// Context a named combination of user creds and cluster info
+type Context struct {
+  Name string
+  ClusterInfo Cluster
+  UserInfo User
+}
+
+// Config shipyardctl configuration object
+type Config struct {
+  CurrentContext string // name of current Context
+  Contexts []Context
+}


### PR DESCRIPTION
Addresses #28 
- change `shipyardctl get token` to `shipyardctl login` 
- write credentials (username and auth token) to config file `~/.shipyardctl/config` (instead of dumping to `stdout`)
- read auth token from in this order: cli flag, environment, config file
