### PR TITLE
add create image nodeVersion flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ _Note: this token expires quickly, so make sure to refresh it about every 30 min
 The build command takes the name of your application, the revision number, the public port/path to reach your application
 and the path to your zipped Node app.
 
+**This command defaults to using Node.js LTS (v4) unless otherwise specified with the `--node-version` flag.**
+**A list of available versions can be found [here](https://github.com/mhart/alpine-node#minimal-nodejs-docker-images-18mb-or-67mb-compressed). Provide the desired image tag as the `--node-version`.**
+
 _Note: there must be a valid package.json in the root of zipped application_
 
 **Verify image creation**

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var nodeVersion string
+
 // imageCmd represents the image command
 var imageCmd = &cobra.Command{
 	Use:   "image <appName> <revision> <publicPath> <zipPath>",
@@ -78,6 +80,7 @@ $ shipyardctl create image example 1 "9000:/example" "./path/to/zipped/app --org
 		writer.WriteField("revision", revision)
 		writer.WriteField("name", appName)
 		writer.WriteField("publicPath", publicPath)
+		writer.WriteField("nodeVersion", nodeVersion)
 
 		err = writer.Close()
 		if err != nil {
@@ -253,6 +256,7 @@ func init() {
 	createCmd.AddCommand(imageCmd)
 	imageCmd.Flags().StringSliceVarP(&envVars, "env", "e", []string{}, "Environment variable to set in the built image \"KEY=VAL\" ")
 	imageCmd.Flags().StringVarP(&orgName, "org", "o", "", "Apigee org name")
+	imageCmd.Flags().StringVarP(&nodeVersion, "node-version", "n", "4", "Node version to use in base image.")
 
 	getCmd.AddCommand(getImageCmd)
 	getImageCmd.Flags().StringVarP(&orgName, "org", "o", "", "Apigee org name")


### PR DESCRIPTION
Fixes client part of [#166](https://github.com/30x/project-management/issues/166)
- adds `--node-version | -n` to `shipyardctl create image`. defaults to `mhart/alpine-node:4`
- list of available versions are here https://github.com/mhart/alpine-node#minimal-nodejs-docker-images-18mb-or-67mb-compressed
- updated README to note this
