### PR TITLE
change image build env-var flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ This command consumes the Node.js application zip, builds it into an image, stor
 > export PTS_URL="<copy the Pod Template Spec URL generated and output by the build image command>"
 ```
 The build command takes the name of your application, the revision number, the public port/path to reach your application
-and the path to your zipped Node app. If you want to bake an environment variable into the image, provide them individually with `--env=MY_VAR=VALUE` or `-e MY_VAR=VAL`. These values can be overwritten by specifying a variable with the same name but different value when deploying the image (covered further down).
+and the path to your zipped Node app. If you want to bake an environment variable into the image, provide them individually with `--env-var=MY_VAR=VALUE`. These values can be overwritten by specifying a variable with the same name but different value when deploying the image (covered further down).
 
 **This command defaults to using Node.js LTS (v4) unless otherwise specified with the `--node-version` flag.**
 **A list of available versions can be found [here](https://github.com/mhart/alpine-node#minimal-nodejs-docker-images-18mb-or-67mb-compressed). Provide the desired image tag as the `--node-version`.**

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -325,7 +325,7 @@ func deleteImage(appName string, revision string) int {
 
 func init() {
 	createCmd.AddCommand(imageCmd)
-	imageCmd.Flags().StringSliceVarP(&envVars, "env", "e", []string{}, "Environment variable to set in the built image \"KEY=VAL\" ")
+	imageCmd.Flags().StringSliceVar(&envVars, "env-var", []string{}, "Environment variable to set in the built image \"KEY=VAL\" ")
 	imageCmd.Flags().StringVarP(&orgName, "org", "o", "", "Apigee org name")
 	imageCmd.Flags().StringVarP(&nodeVersion, "node-version", "n", "4", "Node version to use in base image.")
 


### PR DESCRIPTION
Fixes #40 

There was confusion around the `-e --env` flag in `shipyardctl create image` being for naming an environment to target, when it is actually for specifying build-time environment variables. 

* changes `shipyardctl create image` flag from `--env` to `--envVar` and removes the shorthand `-e`