### PR TITLE
remove replicas/hostnames from deploy app

### DIFF
--- a/cmd/application-deploy.go
+++ b/cmd/application-deploy.go
@@ -37,8 +37,6 @@ type Deployment struct {
 	Replicas       int64
 	PtsUrl         string
 	EnvVars        []EnvVar
-	PublicHosts    string
-	PrivateHosts   string
 }
 
 type deploymentPatch struct {
@@ -299,7 +297,7 @@ $ shipyardctl deploy application -o acme -e test -n example --pts-url "https://p
 
 func deployApplication(envName string, depName string, replicas int64, ptsUrl string, vars []EnvVar) int {
 	// prepare arguments in a Deployment struct and Marshal into JSON
-	js, err := json.Marshal(Deployment{depName, replicas, ptsUrl, vars, hostnames, hostnames})
+	js, err := json.Marshal(Deployment{depName, replicas, ptsUrl, vars})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -537,8 +535,6 @@ func init() {
 	deployApplicationCmd.Flags().StringVarP(&envName, "env", "e", "", "Apigee environment name")
 	deployApplicationCmd.Flags().StringVarP(&appName, "name", "n", "", "name of application deployment to deploy")
 	deployApplicationCmd.Flags().StringVarP(&ptsUrl, "pts-url", "p", "", "URL of the Pod Template Spec given by import")
-	deployApplicationCmd.Flags().IntVarP(&replicasDeploy, "replicas", "r", 1, "Number of application replicas to deploy")
-	deployApplicationCmd.Flags().StringVarP(&hostnames, "hostnames", "s", "", "Accepted hostnames for the deployment")
 
 	updateCmd.AddCommand(updateDeploymentCmd)
 	updateDeploymentCmd.Flags().StringVarP(&orgName, "org", "o", "", "Apigee organization name")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,14 +45,14 @@ var runtime string
 var directory string
 var ptsUrl string
 var replicasUpdate int
-var replicasDeploy int
 var hostnames string
 var bundlePath string
 var bundleName string
 
 var supportedRuntimes = "node"
-
 var config *utils.Config
+
+const replicasDeploy = 1
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{


### PR DESCRIPTION
command in question: `shipyard deploy application`

* removed `--hostnames` that specified the `public/private hosts` of a deployment
* removed `--replicas` and defaulted the # of replicas to 1

Fixes #61 