### PR TITLE
remove appPath from import

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -39,16 +39,6 @@ func RequireAppName() error {
 	return nil
 }
 
-// RequireAppPath used to short circuit commands
-// requiring the app path if it is not present
-func RequireAppPath() error {
-	if appPath == "" {
-		return fmt.Errorf("Missing required flag '--path'.")
-	}
-
-	return nil
-}
-
 // RequireBundleName used to short circuit commands
 // requiring the bundle name be provided via the name flag
 func RequireBundleName() error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,6 @@ var envVars []string
 var sso_target string
 
 var appName string
-var appPath string
 var runtime string
 var directory string
 var ptsUrl string


### PR DESCRIPTION
command in question: `shipyardctl import application`

* removes `--path` arg that represents the application's `publicPath`