### PR TITLE
change deploy proxy to one shot

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -16,25 +16,26 @@ package cmd
 
 import (
 	"fmt"
-	"text/template"
-	"os"
 	"io/ioutil"
+	"os"
 	"path/filepath"
-	"github.com/30x/zipper"
+	"text/template"
+
 	"github.com/30x/shipyardctl/mgmt"
+	"github.com/30x/zipper"
 
 	"github.com/spf13/cobra"
 )
 
 type Bundle struct {
-	Name string
-	BasePath string
-	PublicPath string
+	Name       string
+	BasePath   string
+	TargetPath string
 }
 
 var savePath string
 var base string
-var publicPath string
+var targetPath string
 var fileMode os.FileMode
 
 // bundleCmd represents the bundle command
@@ -48,122 +49,23 @@ Example of use:
 
 $ shipyardctl create bundle -n exampleName`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-    if err := RequireBundleName(); err != nil {
-      return err
-    }
+		if err := RequireBundleName(); err != nil {
+			return err
+		}
 
-    return nil
-  },
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// make a temp dir
-		tmpdir, err := ioutil.TempDir("", orgName+"_"+envName)
-		if err != nil {
-			fmt.Println("Failed to make a temporary directory")
-			return
-		}
-
-		if verbose {
-			fmt.Println("Creating tmpdir at: "+tmpdir)
-		}
-
+		zipDir, tmpdir, err := MakeProxyBundle(bundleName)
 		defer os.RemoveAll(tmpdir)
-
-		// make apiproxy directory structure
-		dir := filepath.Join(tmpdir, "apiproxy")
-		err = os.Mkdir(dir, fileMode)
-
-		if verbose {
-			fmt.Println("Creating folder 'apiproxy' at: "+dir)
-		}
-		checkError(err, "Unable to make root apiproxy dir")
-
-		proxiesDirPath := filepath.Join(dir, "proxies")
-		err = os.Mkdir(proxiesDirPath, fileMode)
-		if verbose {
-			fmt.Println("Creating subfolder 'proxies' at: "+proxiesDirPath)
-		}
-		checkError(err, "Unable to make proxies dir")
-
-		targetsDirPath := filepath.Join(dir, "targets")
-		err = os.Mkdir(targetsDirPath, fileMode)
-		if verbose {
-			fmt.Println("Creating subfolder 'targets' at: "+targetsDirPath)
-		}
-		checkError(err, "Unable to make targets dir")
-
-		policiesDirPath := filepath.Join(dir, "policies")
-		err = os.Mkdir(policiesDirPath, fileMode)
-		if verbose {
-			fmt.Println("Creating subfolder 'policies' at: "+policiesDirPath)
-		}
-		checkError(err, "Unable to make policies dir")
-
-		// bundle user info for templates
-		if base == "" {
-			base = publicPath
-		}
-
-		bundle := Bundle{bundleName, base, publicPath}
-
-		// example.xml --> ./apiproxy/
-		proxy_xml, err := os.Create(filepath.Join(dir, bundleName+".xml"))
-		err = proxy_xml.Chmod(fileMode)
-		if verbose {
-			fmt.Println("Creating file '"+bundleName+".xml'")
-		}
-		checkError(err, "Unable to make "+bundleName+".xml file")
-
-		proxyTmpl, err := template.New("PROXY").Parse(PROXY_XML)
-		if err != nil { panic(err) }
-		err = proxyTmpl.Execute(proxy_xml, bundle)
-		if err != nil { panic(err) }
-
-		// AddCors.xml --> ./apiproxy/policies
-		add_cors_xml, err := os.Create(filepath.Join(policiesDirPath, "AddCors.xml"))
-		err = add_cors_xml.Chmod(fileMode)
-		if verbose {
-			fmt.Println("Creating file 'policies/AddCors.xml'")
-		}
-		checkError(err, "Unable to make AddCors.xml file")
-
-		addCors, err := template.New("ADD_CORS").Parse(ADD_CORS)
-		if err != nil { panic(err) }
-		err = addCors.Execute(add_cors_xml, bundle)
-		if err != nil { panic(err) }
-
-		// default.xml --> ./apiproxy/proxies && ./apiproxy/targets
-		proxy_default_xml, err := os.Create(filepath.Join(proxiesDirPath, "default.xml"))
-		err = proxy_default_xml.Chmod(fileMode)
-		if verbose {
-			fmt.Println("Creating file 'proxies/default.xml'")
-		}
-		checkError(err, "Unable to make default.xml file")
-
-		target_default_xml, err := os.Create(filepath.Join(targetsDirPath, "default.xml"))
-		err = target_default_xml.Chmod(fileMode)
-		if verbose {
-			fmt.Println("Creating file 'targets/default.xml'")
-		}
-		checkError(err, "Unable to make default.xml file")
-
-		proxyEndpoint, err := template.New("PROXY_ENDPOINT").Parse(PROXY_ENDPOINT)
-		if err != nil { panic(err) }
-		err = proxyEndpoint.Execute(proxy_default_xml, bundle)
-		if err != nil { panic(err) }
-
-		targetEndpoint, err := template.New("TARGET_ENDPOINT").Parse(TARGET_ENDPOINT)
-		err = targetEndpoint.Execute(target_default_xml, bundle)
-		if err != nil { panic(err) }
-
-		zipDir := filepath.Join(tmpdir, bundleName+".zip")
-		err = zipper.Archive(dir, zipDir)
-		if err != nil { panic(err) }
+		checkError(err, "Problmem making proxy bundle")
 
 		// move zip to designated savePath
 		if savePath != "" {
 			err = os.Rename(zipDir, filepath.Join(savePath, bundleName+".zip"))
 			if verbose {
-				fmt.Println("Moving proxy folder to "+savePath)
+				fmt.Println("Moving proxy folder to " + savePath)
 			}
 			checkError(err, "Unable to move apiproxy to target save directory")
 		} else { // move apiproxy from tmpdir to cwd
@@ -176,15 +78,15 @@ $ shipyardctl create bundle -n exampleName`,
 		}
 
 		if verbose {
-				fmt.Println("Deleting tmpdir")
-			}
+			fmt.Println("Deleting tmpdir")
+		}
 	},
 }
 
 var deployProxyCmd = &cobra.Command{
-  Use:   "proxy",
-  Short: "deploys a given proxy bundle Edge",
-  Long: `This command consumes a Node.js application archive, deploys it to Shipyard,
+	Use:   "proxy",
+	Short: "deploys a given proxy bundle Edge",
+	Long: `This command consumes a Node.js application archive, deploys it to Shipyard,
 and creates an appropriate Edge proxy.
 
 $ shipyardctl deploy proxy -o acme -e test -z /path/to/bundle/zip `,
@@ -205,18 +107,167 @@ $ shipyardctl deploy proxy -o acme -e test -z /path/to/bundle/zip `,
 			return err
 		}
 
-		if err := RequireZipPath(); err != nil {
-			return err
-		}
-
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		err := mgmt.UploadProxyBundle(config.GetCurrentMgmtAPITarget(), orgName, envName, config.GetCurrentToken(), bundlePath, appName, verbose)
+		var err error
+		var tmpdir string
+
+		if bundlePath == "" {
+			bundlePath, tmpdir, err = MakeProxyBundle(appName)
+			defer os.RemoveAll(tmpdir)
+			checkError(err, "Problem building proxy bundle")
+		}
+
+		err = mgmt.UploadProxyBundle(config.GetCurrentMgmtAPITarget(), orgName, envName, config.GetCurrentToken(), bundlePath, appName, verbose)
 		checkError(err, "")
 	},
 }
 
+func MakeProxyBundle(name string) (string, string, error) {
+	// make a temp dir
+	tmpdir, err := ioutil.TempDir("", orgName+"_"+envName)
+	if err != nil {
+		return "", "", err
+	}
+
+	if verbose {
+		fmt.Println("Creating tmpdir at: " + tmpdir)
+	}
+
+	// make apiproxy directory structure
+	dir := filepath.Join(tmpdir, "apiproxy")
+	err = os.Mkdir(dir, fileMode)
+
+	if verbose {
+		fmt.Println("Creating folder 'apiproxy' at: " + dir)
+	}
+
+	if err != nil {
+		return "", "", err
+	}
+
+	proxiesDirPath := filepath.Join(dir, "proxies")
+	err = os.Mkdir(proxiesDirPath, fileMode)
+	if verbose {
+		fmt.Println("Creating subfolder 'proxies' at: " + proxiesDirPath)
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	targetsDirPath := filepath.Join(dir, "targets")
+	err = os.Mkdir(targetsDirPath, fileMode)
+	if verbose {
+		fmt.Println("Creating subfolder 'targets' at: " + targetsDirPath)
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	policiesDirPath := filepath.Join(dir, "policies")
+	err = os.Mkdir(policiesDirPath, fileMode)
+	if verbose {
+		fmt.Println("Creating subfolder 'policies' at: " + policiesDirPath)
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	// bundle user info for templates
+	if base == "" {
+		base = fmt.Sprintf("/%s", name)
+	}
+
+	if targetPath == "" {
+		targetPath = fmt.Sprintf("/%s", name)
+	}
+
+	bundle := Bundle{name, base, targetPath}
+
+	// example.xml --> ./apiproxy/
+	proxy_xml, err := os.Create(filepath.Join(dir, name+".xml"))
+	err = proxy_xml.Chmod(fileMode)
+	if verbose {
+		fmt.Println("Creating file '" + name + ".xml'")
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	proxyTmpl, err := template.New("PROXY").Parse(PROXY_XML)
+	if err != nil {
+		return "", "", err
+	}
+
+	err = proxyTmpl.Execute(proxy_xml, bundle)
+	if err != nil {
+		return "", "", err
+	}
+
+	// AddCors.xml --> ./apiproxy/policies
+	add_cors_xml, err := os.Create(filepath.Join(policiesDirPath, "AddCors.xml"))
+	err = add_cors_xml.Chmod(fileMode)
+	if verbose {
+		fmt.Println("Creating file 'policies/AddCors.xml'")
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	addCors, err := template.New("ADD_CORS").Parse(ADD_CORS)
+	if err != nil {
+		return "", "", err
+	}
+
+	err = addCors.Execute(add_cors_xml, bundle)
+	if err != nil {
+		return "", "", err
+	}
+
+	// default.xml --> ./apiproxy/proxies && ./apiproxy/targets
+	proxy_default_xml, err := os.Create(filepath.Join(proxiesDirPath, "default.xml"))
+	err = proxy_default_xml.Chmod(fileMode)
+	if verbose {
+		fmt.Println("Creating file 'proxies/default.xml'")
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	target_default_xml, err := os.Create(filepath.Join(targetsDirPath, "default.xml"))
+	err = target_default_xml.Chmod(fileMode)
+	if verbose {
+		fmt.Println("Creating file 'targets/default.xml'")
+	}
+	if err != nil {
+		return "", "", err
+	}
+
+	proxyEndpoint, err := template.New("PROXY_ENDPOINT").Parse(PROXY_ENDPOINT)
+	if err != nil {
+		return "", "", err
+	}
+
+	err = proxyEndpoint.Execute(proxy_default_xml, bundle)
+	if err != nil {
+		return "", "", err
+	}
+
+	targetEndpoint, err := template.New("TARGET_ENDPOINT").Parse(TARGET_ENDPOINT)
+	err = targetEndpoint.Execute(target_default_xml, bundle)
+	if err != nil {
+		return "", "", err
+	}
+
+	zipDir := filepath.Join(tmpdir, name+".zip")
+	err = zipper.Archive(dir, zipDir)
+	if err != nil {
+		return "", "", err
+	}
+
+	return zipDir, tmpdir, nil
+}
 
 func checkError(err error, customMsg string) {
 	if err != nil {
@@ -233,13 +284,15 @@ func init() {
 	createCmd.AddCommand(bundleCmd)
 	bundleCmd.Flags().StringVarP(&bundleName, "name", "n", "", "Proxy bundle name")
 	bundleCmd.Flags().StringVarP(&savePath, "save", "s", "", "Save path for proxy bundle")
-	bundleCmd.Flags().StringVarP(&base, "basePath", "b", "", "Proxy base path. Defaults to /")
-	bundleCmd.Flags().StringVarP(&publicPath, "publicPath", "p", "/", "Application public path. Defaults to /")
+	bundleCmd.Flags().StringVarP(&base, "basePath", "b", "/", "Proxy base path. Defaults to /{name}")
+	bundleCmd.Flags().StringVarP(&targetPath, "targetPath", "p", "/", "Application public path. Defaults to /{name}")
 
 	deployCmd.AddCommand(deployProxyCmd)
 	deployProxyCmd.Flags().StringVarP(&orgName, "org", "o", "", "Apigee organization name")
 	deployProxyCmd.Flags().StringVarP(&envName, "env", "e", "", "Apigee environment name")
 	deployProxyCmd.Flags().StringVarP(&appName, "name", "n", "", "name of proxy to be deployed")
+	deployProxyCmd.Flags().StringVarP(&base, "basePath", "b", "", "Proxy base path. Defaults to /{name}")
+	deployProxyCmd.Flags().StringVarP(&targetPath, "targetPath", "p", "/", "Target base path. Defaults to /{name}")
 	deployProxyCmd.Flags().StringVarP(&bundlePath, "zip-path", "z", "", "path to the proxy bundle zip")
 
 	fileMode = 0755

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -18,7 +18,7 @@ var TARGET_ENDPOINT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     </PostFlow>
     <Flows/>
     <ScriptContainer>
-        <ResourceURL>{{.PublicPath}}</ResourceURL>
+        <ResourceURL>{{.TargetPath}}</ResourceURL>
     </ScriptContainer>
 </TargetEndpoint>`
 


### PR DESCRIPTION
Fixes #62 

command in question: `shipyardctl deploy proxy`

* if no specific `--zip-path` is given, a proxy bundle will be created in-memory, uploaded, then the local copy deleted
* changed defaults for proxy base & target paths from `/` to `/{name}`