### PR TITLE
add edge-config values

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ var directory string
 var bundlePath string
 var bundleName string
 var force bool
+var edgeConfigs []string
 
 var supportedRuntimes = "node"
 var config *utils.Config


### PR DESCRIPTION
adds `--edge-config="{ENV_VAR_NAME}={MAP_NAME}:{KEY_NAME}"` to `deploy application` in order to enable mapping deployment env vars to Edge configuration values.

Fixes #53 